### PR TITLE
PackageManager: Add checks on write rights

### DIFF
--- a/src/PackageManager.h
+++ b/src/PackageManager.h
@@ -51,6 +51,7 @@ class PackageManager final : public QWidget
     Ui_PackageManager *m_ui;
     QProcess *m_pythonProcess;
     CommandOutputDialog *m_outputDialog;
+    bool m_shouldUseUserOption;
 };
 
 #endif // PYTHON_PLUGIN_PACKAGE_MANAGER_H

--- a/src/PythonConfig.h
+++ b/src/PythonConfig.h
@@ -87,12 +87,6 @@ class PythonConfig final
         Unknown
     };
 
-    /// # On Windows:
-    /// Initialize python home and python path
-    /// corresponding to the environment to be used.
-    ///
-    /// # Other Platforms
-    /// Does nothing, as we rely on the system's python to be properly installed
     PythonConfig() = default;
 
     Type type() const
@@ -118,6 +112,11 @@ class PythonConfig final
             break;
         }
         return o;
+    }
+
+    const QString &pythonHome() const
+    {
+        return m_pythonHome;
     }
 
     /// Sets the necessary settings of the QProcess so that
@@ -148,6 +147,12 @@ class PythonConfig final
     static bool IsInsideEnvironment();
     static PythonConfig fromContainingEnvironment();
 
+    /// # On Windows:
+    /// Initialize python home and python path
+    /// corresponding to the environment to be used.
+    ///
+    /// # Other Platforms
+    /// Does nothing, as we rely on the system's python to be properly installed
     void initDefault();
 #ifdef Q_OS_WIN32
     /// Initialize the paths to point to where the Python

--- a/src/Ui/PackageManager.ui
+++ b/src/Ui/PackageManager.ui
@@ -6,16 +6,55 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>660</width>
-    <height>425</height>
+    <width>694</width>
+    <height>495</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Packages</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QFrame" name="messageFrame">
+       <property name="frameShape">
+        <enum>QFrame::Box</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="messageIconLabel">
+          <property name="text">
+           <string>TextLabel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="messageTextLabel">
+          <property name="text">
+           <string>TextLabel</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="messageSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>456</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
      <item>
       <widget class="QLineEdit" name="searchBar"/>
      </item>


### PR DESCRIPTION
To be able to install a package, the package manager calls pip, pip needs to have write permissions otherwise it will fail.

CloudCompare on windows being generally installed in C:\Programs that requires admin rights, so a non admin cannot pip install things in there.

There have been many user confused by this, so its easier to block installation and have a message if we detect the folder is not writable

Also, the package manager should now automatically use the `--user` option for pip install when it's using the system's Python