### PR TITLE
embedded python on MacOS

### DIFF
--- a/src/PythonConfig.cpp
+++ b/src/PythonConfig.cpp
@@ -171,7 +171,7 @@ static QString PathToPythonExecutableInEnv(PythonConfig::Type envType, const QSt
 
 void PythonConfig::initDefault()
 {
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
     initBundled();
 #else
     // On Non windows platform
@@ -180,10 +180,14 @@ void PythonConfig::initDefault()
 #endif
 }
 
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
 void PythonConfig::initBundled()
 {
+#if defined(Q_OS_MACOS)
+    const QString pythonEnvDirPath(QApplication::applicationDirPath() + "/../Resources/python");
+#else
     const QString pythonEnvDirPath(QApplication::applicationDirPath() + "/plugins/Python");
+#endif
     initFromLocation(pythonEnvDirPath);
 }
 #endif
@@ -231,6 +235,22 @@ void PythonConfig::initFromLocation(const QString &prefix)
         }
     }
     else
+#if defined(Q_OS_MACOS)
+    {
+		QString pythonExePath = PathToPythonExecutableInEnv(Type::Unknown, prefix);
+		initFromPythonExecutable(pythonExePath);
+		if (m_pythonHome.isEmpty() && m_pythonPath.isEmpty())
+		{
+			qDebug() << "Failed to get paths info from python executable at (bundled)"
+					 << pythonExePath;
+			initVenv(envRoot.path());
+		}
+		else
+		{
+			m_type = Type::Unknown;
+		}
+    }
+#else
     {
         m_pythonHome = envRoot.path();
         m_pythonPath = QString("%1/DLLs;%1/lib;%1/Lib/site-packages;").arg(m_pythonHome);
@@ -240,6 +260,7 @@ void PythonConfig::initFromLocation(const QString &prefix)
         m_pythonPath.append(WindowsBundledSitePackagesPath());
 #endif
     }
+#endif
 }
 
 void PythonConfig::initCondaEnv(const QString &condaPrefix)

--- a/src/PythonConfig.h
+++ b/src/PythonConfig.h
@@ -154,7 +154,7 @@ class PythonConfig final
     /// # Other Platforms
     /// Does nothing, as we rely on the system's python to be properly installed
     void initDefault();
-#ifdef Q_OS_WIN32
+#if defined(Q_OS_WIN32) || defined(Q_OS_MACOS)
     /// Initialize the paths to point to where the Python
     /// environment was bundled on a Windows installation
     void initBundled();

--- a/src/PythonRuntimeSettings.cpp
+++ b/src/PythonRuntimeSettings.cpp
@@ -144,9 +144,10 @@ PythonRuntimeSettings::PythonRuntimeSettings(QWidget *parent)
 {
     m_ui->setupUi(this);
     m_ui->localEnvSettingsWidget->hide();
-#if defined(Q_OS_WIN)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
     m_ui->envTypeComboBox->addItem("Bundled");
-#else
+#endif
+#if defined(Q_OS_LINUX) || defined(Q_OS_MACOS)
     m_ui->envTypeComboBox->addItem("System");
 #endif
     m_ui->envTypeComboBox->addItem("Local");
@@ -264,7 +265,7 @@ PythonConfig PythonRuntimeSettings::pythonEnvConfig() const
         config.initDefault();
         return config;
     }
-#if defined(Q_OS_WINDOWS)
+#if defined(Q_OS_WINDOWS) || defined(Q_OS_MACOS)
     if (selectedEnvType() == "Bundled")
     {
         PythonConfig config;


### PR DESCRIPTION
Hello,
I think I have something working on MacOS now, unfortunately not on a Sandboxed app, only with  a HardenedRuntime entitlement. I still have to work on an optimal embedded Python packaging: I have just copied the Python & packages from the conda environment I use for CloudCompare build, but it's unnecessary heavy. I can run scripts with the embedded Python or a with a virtual environnment outside (and the package management works in that case).