### PR TITLE
Fix for pybind11>=2.12

### DIFF
--- a/wrapper/cccorelib/src/cccorelib.cpp
+++ b/wrapper/cccorelib/src/cccorelib.cpp
@@ -146,7 +146,7 @@ class NumpyCloud : public CCCoreLib::GenericIndexedCloud
 
         py::list names;
 #if ((PYBIND11_VERSION_MAJOR > 2) || (PYBIND11_VERSION_MAJOR == 2 && PYBIND11_VERSION_MINOR > 11))
-        // The "name" field is no longer available in Descr_Proxy struct,
+        // The "names" field is no longer available in Descr_Proxy struct,
         // but it is available on both Descr1_Proxy and Descr2_Proxy structs
 
         // Get the currrent numpy version


### PR DESCRIPTION
Fix compilation with `pybind11` >= 2.12 and compatibility with `Numpy `2.0.
in [pybind11 2.12](https://github.com/pybind/pybind11/blob/f33f6afb667b6b5c0da7dee98dc02f51b4cc0e96/include/pybind11/numpy.h#L84-L92) `PyArrayDescr_Proxy` no longer have a `names` field. 

Two possible alternatives
- We could use the `PYBIND11_NUMPY_1_ONLY` [definition to restrict the usage](https://pybind11.readthedocs.io/en/stable/upgrade.html) of CCPython-Runtime to numpy [1.7,2.0)
- We could remove temporarly the NumpyCloud class as it seems not finished nor used yet.  