### PR TITLE
Update ccGuiPythonInstance.cpp and prevent crash

### DIFF
--- a/src/Runtime/ccGuiPythonInstance.cpp
+++ b/src/Runtime/ccGuiPythonInstance.cpp
@@ -165,7 +165,8 @@ void ccGuiPythonInstance::removeFromDB(pybind11::object &obj)
         // it'll be a use after free.
         m_app->removeFromDB(hobj, false /*delete*/);
         Q_ASSERT(obj.ref_count() >= 2);
-        obj.dec_ref();
+        // obj.dec_ref();
+        obj = pybind11::none();
     }
     catch (const pybind11::cast_error &)
     {


### PR DESCRIPTION
Sometimes, `removefromdb` causes the Python plugin and CC software to crash.

Ubuntu 22.04
Python 3.11

![image](https://github.com/user-attachments/assets/2badc0ed-0a32-4c6e-97b4-ea5b33b91881)
![image](https://github.com/user-attachments/assets/65589620-863e-47f7-8fd1-1189483ad5eb)


After modification, the user can also use Python objects.
![image](https://github.com/user-attachments/assets/6f162de8-ab74-4fac-8589-11b5ca1c10a4)
![image](https://github.com/user-attachments/assets/bccbf855-b630-4791-b8b5-8265fe571fe8)

