### PR TITLE
Load plugins in separate thread

### DIFF
--- a/src/CodeEditor/PythonEditor.cpp
+++ b/src/CodeEditor/PythonEditor.cpp
@@ -45,6 +45,8 @@ PythonEditor::PythonEditor(PythonInterpreter *interpreter)
     readSettings();
     QCoreApplication::instance()->installEventFilter(this);
 
+    actionRun->setEnabled(!interpreter->isExecuting());
+
     connect(this, &PythonEditor::executionCalled, interpreter, &PythonInterpreter::executeCode);
     connect(
         interpreter, &PythonInterpreter::executionStarted, this, &PythonEditor::executionStarted);

--- a/src/PythonInterpreter.cpp
+++ b/src/PythonInterpreter.cpp
@@ -150,6 +150,10 @@ void PythonInterpreter::executeStatementWithState(const std::string &code,
 
 void PythonInterpreter::executeCode(const std::string &code, QListWidget *output)
 {
+    if (m_isExecuting)
+    {
+        return;
+    }
     State tmpState;
     executeCodeWithState(code, output, tmpState);
 }

--- a/src/PythonPluginManager.cpp
+++ b/src/PythonPluginManager.cpp
@@ -27,6 +27,37 @@ const std::vector<Runtime::RegisteredPlugin> &PythonPluginManager::plugins() con
     return m_plugins;
 }
 
+void PythonPluginManager::loadPlugins(const QStringList &pluginsPaths) noexcept
+{
+    // Start by autodiscovering plugins from metadata
+    try
+    {
+        loadPluginsFromEntryPoints();
+    }
+    catch (const std::exception &e)
+    {
+        plgWarning() << "Failed to load autodiscovered custom python plugins: " << e.what();
+    }
+    catch (...)
+    {
+        plgWarning() << "Failed to load autodiscovered custom python plugins";
+    }
+
+    // In the end, we add plugins from custom paths
+    try
+    {
+        loadPluginsFrom(pluginsPaths);
+    }
+    catch (const std::exception &e)
+    {
+        plgWarning() << "Failed to load custom python plugins: " << e.what();
+    }
+    catch (...)
+    {
+        plgWarning() << "Failed to load custom python plugins";
+    }
+}
+
 void PythonPluginManager::loadPluginsFromEntryPoints()
 {
     plgPrint() << "Searching for custom plugins (checking metadata in site-package)";

--- a/src/PythonPluginManager.h
+++ b/src/PythonPluginManager.h
@@ -31,6 +31,18 @@ class PythonPluginManager final
     /// Returns the currently loaded plugins
     const std::vector<Runtime::RegisteredPlugin> &plugins() const;
 
+    /// load plugins
+    ///
+    /// * First loads plugins from the `cloudcompare.plugins` entry point
+    /// * Then loads plugins from the given paths
+    ///
+    /// Errors are logged.
+    void loadPlugins(const QStringList &pluginsPaths) noexcept;
+
+    /// This MUST be called before finalizing the interpreter
+    void unloadPlugins();
+
+  private:
     /// Autodiscover plugins based on the package metadata.
     /// it uses the entry point mechanism described
     /// - In PyPa docs:
@@ -50,10 +62,6 @@ class PythonPluginManager final
     /// \param paths where we will look for plugins to load
     void loadPluginsFrom(const QStringList &paths);
 
-    /// This MUST be called before finalizing the interpreter
-    void unloadPlugins();
-
-  private:
     std::vector<Runtime::RegisteredPlugin> m_plugins;
 };
 


### PR DESCRIPTION
This puts the loading of python plugins in a different thread as they may take some time to load and we want the app to open as fast as possible

- [ ] Test with the 3DFIN plugin