### PR TITLE
Always define python regardless of python version

### DIFF
--- a/src/PythonConfig.cpp
+++ b/src/PythonConfig.cpp
@@ -311,14 +311,7 @@ void PythonConfig::preparePythonProcess(QProcess &pythonProcess) const
 PythonConfigPaths PythonConfig::pythonCompatiblePaths() const
 {
     PythonConfigPaths paths;
-    if (getVersion().minor >= 10)
-    {
-        paths.m_pythonHome.reset(nullptr);
-    }
-    else
-    {
-        paths.m_pythonHome.reset(QStringToWcharArray(m_pythonHome));
-    }
+    paths.m_pythonHome.reset(QStringToWcharArray(m_pythonHome));
     paths.m_pythonPath.reset(QStringToWcharArray(m_pythonPath));
     return paths;
 }


### PR DESCRIPTION
I had do add this because I was having problems with older python version, but maybe it was more due to a bad install ?