### PR TITLE
Actually use pybind11 3.0 in CI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install Dependencies
         run: |
           conda install -c conda-forge qt6-main==6.8.3 ninja doxygen
-          pip install pytest pybind11<3.0 numpy
+          pip install pytest "pybind11>=3.0" numpy
 
       - name: Configure MSVC console
         uses: ilammy/msvc-dev-cmd@v1
@@ -167,7 +167,7 @@ jobs:
           brew install qt6 ninja
           echo "CMAKE_PREFIX_PATH=$(brew --prefix qt@6)" >> $GITHUB_ENV
           pip install --upgrade pip
-          pip install pytest "pybind11<3.0"
+          pip install pytest "pybind11>=3.0"
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
The ubuntu pybind11-dev is still 2.x I believe,
but since the part of pybind11 we use is backward compatible this is fine